### PR TITLE
11 clipboard chain fragile

### DIFF
--- a/src/ClipboardToFile.cpp
+++ b/src/ClipboardToFile.cpp
@@ -52,6 +52,7 @@
 #define ID_MENU_EXIT                1005
 
 const wchar_t CLASS_NAME[] = L"ClipboardToFileWindowClass";
+const wchar_t* REG_APP_KEY = L"Software\\ByronAP\\ClipboardToFile";
 HWND  g_hMainWnd = NULL;
 HWND  g_hNextClipboardViewer = NULL;
 HANDLE g_hWatcherThread = NULL;
@@ -371,8 +372,6 @@ AppVersion GetCurrentAppVersion() {
     }
     return {};
 }
-
-const wchar_t* REG_APP_KEY = L"Software\\ByronAP\\ClipboardToFile";
 
 // Background thread function that performs the network request to the GitHub API.
 DWORD WINAPI PerformUpdateCheck(LPVOID) {


### PR DESCRIPTION
Fix #11 

[Use modern clipboard listener API](https://github.com/ByronAP/ClipboardToFile/commit/28e16ea8477944c5dec8b0bfa7f5e13625e02e5e)

also

[Move REG_APP_KEY to its proper location](https://github.com/ByronAP/ClipboardToFile/commit/70ae8f30754378e498bb4780d169cee03ba05137)